### PR TITLE
樹録完了のダイアログ画面作成

### DIFF
--- a/PrismStep/ResultDialogView.swift
+++ b/PrismStep/ResultDialogView.swift
@@ -1,0 +1,62 @@
+//
+//  ResultDialogView.swift
+//  PrismStep
+//
+//  Created by 三上凪咲 on 2025/12/18.
+//
+
+import SwiftUI
+
+struct ResultDialogView: View {
+    
+    // 閉じるボタンが押されたことを、親（ContentView）に伝えるための「スイッチ」
+        var closeAction: () -> Void
+    
+    var body: some View {
+        ZStack {
+                    // 1. 背景（画面全体を少し暗くする）
+                    Color.black.opacity(0.4)
+                        .ignoresSafeArea()
+                        // 暗い部分をタップしても閉じれるようにする（お好みで）
+                        .onTapGesture {
+                            closeAction()
+                        }
+                    
+                    // 2. メインの白いカード
+                    VStack(spacing: 20) {
+                        Text("樹録完了")
+                            .font(.title2)
+                            .fontWeight(.bold)
+                            .foregroundColor(Color(red: 0.8, green: 0.6, blue: 0.2)) // 金色っぽい色
+                        
+                        // 花の画像（今は仮の円）
+                        ZStack {
+                            Circle()
+                                .fill(Color.pink.opacity(0.2))
+                                .frame(width: 120, height: 120)
+                            
+                            Text("仮の花")
+                                .font(.headline)
+                        }
+                        .padding(.vertical, 10)
+                        
+                        // 閉じるボタン（画面全体をタップでも閉じれるけど、明示的に置く）
+                        /*Button(action: {
+                            closeAction()
+                        }) {
+                            Text("閉じる")
+                                .padding()
+                        }*/
+                    }
+                    .frame(width: 300) // カードの幅
+                    .padding(30)
+                    .background(Color.white)
+                    .cornerRadius(20)
+                    .shadow(radius: 10)
+                }
+    }
+}
+
+#Preview {
+    ResultDialogView(closeAction: {})
+}


### PR DESCRIPTION
## 概要
「今日を樹録する」ボタンを押した後に表示されるダイアログのUIパーツを作成した。
今回は`ContentView.swift`への組み込みは行わず、`ResultDialogView.swift`の新規作成のみを行っている。

## 変更点
- **新規作成**：`ResultDialogView.swift`
  - 背景を半透明の黒（タップで閉じる想定）に設定。
  - 中央に白いカードを配置し、「樹録完了」のテキストと仮の画像を表示。

<img width="361" height="671" alt="スクリーンショット 2025-12-18 12 11 06" src="https://github.com/user-attachments/assets/b1f638a8-6a5e-4cf2-8971-3f869dbd90b4" />

## 次のステップ（実装メモ）
次のIssue「樹録ボタンを押して結果ダイアログを表示する処理の実装」にて、`ContentView` に以下のように組み込む予定。

```swift
struct ContentView: View {
    // 表示管理用の変数を追加
    @State var isShowingResult = false

    var body: some View {
        ZStack {
            // ... (既存のカメラやTabView) ...

            // ▼▼▼ 追加：ボタンの配置（TabViewの上に浮くように配置） ▼▼▼
            VStack {
                Spacer()
                
                Button(action: {//「今日を樹録する」ボタン
                    isShowingResult = true//ボタンを押したらスイッチON
                }) {
                    Text("今日を樹録する")
                        .font(.title3)
                        .bold()
                        .foregroundColor(.white)
                        .padding(.vertical, 15)
                        .padding(.horizontal, 40)
                        .background(Color(red: 0.85, green: 0.65, blue: 0.3)) // 黄土色
                        .cornerRadius(30)
                        .shadow(radius: 5)
                }
                .padding(.bottom, 120) // タブバーに被らない位置
            }

            // ▼▼▼ 追加：ダイアログ（最前面） ▼▼▼
            if isShowingResult {
                ResultDialogView(closeAction: {
                    isShowingResult = false//閉じるアクションが呼ばれたらスイッチOFF
                })
                .transition(.opacity) // ふわっと表示
                .zIndex(1)//最前面に表示
            }
        }
    }
}
```

## 関連Issue
Close #16 
