### PR TITLE
Feature/show result dialog

### DIFF
--- a/PrismStep/ContentView.swift
+++ b/PrismStep/ContentView.swift
@@ -89,7 +89,7 @@ struct ContentView : View {
             // タブバーの文字色などを変えたい場合はここに追加設定する
             .tint(.blue) // 選択されているアイコンの色
             
-            VStack {
+            VStack {//ボタンの配置
                             Spacer()
                             
                             Button(action: {//「今日を樹録する」ボタン


### PR DESCRIPTION
## 概要
ContentViewに「今日を樹録する」ボタンを配置し、タップした際に結果ダイアログ（ResultDialogView）が表示される処理を実装した。

## 変更点
- **ContentView.swift**
 - 「今日を樹録する」ボタンをZStackの最前面（下部）に追加
 - ボタン押下時に `ResultDialogView` を表示するロジックを追加
 
<img width="366" height="675" alt="スクリーンショット 2025-12-18 17 35 32" src="https://github.com/user-attachments/assets/3ae5fe2d-3ace-40e7-a79a-7c745ac00e70" />

<img width="358" height="676" alt="スクリーンショット 2025-12-18 17 35 44" src="https://github.com/user-attachments/assets/bd426c35-da54-4f99-9b27-c424bcad9676" />

## 関連Issue
Closes #18 