### PR TITLE
花のいろを個別で変えられる様にした。それぞれの色を定義した。

### DIFF
--- a/PrismStep/FlowerModelConfigurator.swift
+++ b/PrismStep/FlowerModelConfigurator.swift
@@ -17,62 +17,79 @@ struct FlowerModelConfigurator {
         // 影の設定
         model.components.set(GroundingShadowComponent(castsShadow: true))
         
-        // ★色を「サクラピンク」の宝石カラーに統一
-        applyPinkGemMaterial(to: model)
+        // ★以前の「一括でピンクにする処理」は削除しました
+        // applyPinkGemMaterial(to: model)
         
         switch name {
         case "Flower1":
+            // ---------------------------------------------------
+            // Flower1 (芽): #C0E8F0 (ペールシアン)
+            // R:192, G:232, B:240 -> 0.75, 0.91, 0.94
+            // ---------------------------------------------------
+            let color1 = UIColor(red: 0.75, green: 0.91, blue: 0.94, alpha: 1.0)
+            applyGemMaterial(to: model, color: color1)
+            
             // --- Flower1 (蕾) の調整 ---
-            // 上下逆さまにする（180度回転）
+            // (いただいたコードの設定を維持)
             model.orientation = simd_quatf(angle: .pi, axis: [0, 0, 1])
-            model.scale = SIMD3<Float>(0.003, 0.003, 0.003) // 標準サイズ
-            model.position = SIMD3<Float>(0, 0.5, 0)       // 中心位置
+            model.scale = SIMD3<Float>(0.003, 0.003, 0.003)
+            model.position = SIMD3<Float>(0, 0.5, 0)
             
         case "Flower2":
+            // ---------------------------------------------------
+            // Flower2 (蕾): #F8C8DC (ペールピンク)
+            // R:248, G:200, B:220 -> 0.97, 0.78, 0.86
+            // ---------------------------------------------------
+            let color2 = UIColor(red: 0.97, green: 0.78, blue: 0.86, alpha: 1.0)
+            applyGemMaterial(to: model, color: color2)
+            
             // --- Flower2 (小花) の調整 ---
-            // ★追加：モデル自体の傾きを補正する
-                        // Z軸（画面の奥行き方向の軸）を中心に、少しだけ回転させて真っ直ぐに見せます。
-                        // angle: の数字を変えると角度が変わります。
-                        // 試しに「-0.3ラジアン（約-17度）」回転させてみます。
-                        // もし逆方向に傾いたら、プラスの値（0.3など）を試してください。
+            // (いただいたコードの傾き補正・位置調整を維持)
+            
+            // Z軸回転（左右の補正）: 0.3ラジアン
             let rotationZ = simd_quatf(angle: 0.3, axis: [0, 0, 1])
-            // 2. ★追加：「手前に傾ける」（X軸回転）
-                        // axis: [1, 0, 0] が「横方向の軸」を意味します。
-                        // angle: の数字を大きくすると、より深くお辞儀します。
-                        // 試しに「0.5」（約30度）くらい手前に倒してみます。
-                        let rotationX = simd_quatf(angle: 0.5, axis: [1, 0, 0])
+            
+            // X軸回転（手前へのお辞儀）: 0.5ラジアン
+            let rotationX = simd_quatf(angle: 0.5, axis: [1, 0, 0])
+            
+            // 回転を合成
             model.orientation = rotationX * rotationZ
+            
             model.scale = SIMD3<Float>(0.002, 0.002, 0.002)
+            // 位置調整 (x: 0.05)
             model.position = SIMD3<Float>(0.05, -0.3, 0)
             
         case "Flower3":
-            // --- Flower3 (大花) の調整 ---
-            model.scale = SIMD3<Float>(0.005, 0.005, 0.005)
-            model.position = SIMD3<Float>(0, 0.15, 0)
+                    // ---------------------------------------------------
+                    // Flower3 (花): 色を微調整しました！
+                    // 変更前: #DCD0FF (白っぽいラベンダー)
+                    // 変更後: #D1B2F2 (上品なライラック)
+                    // 緑(Green)を少し減らすことで、白さを抑えて紫色を少し主張させました
+                    // ---------------------------------------------------
+                    let color3 = UIColor(red: 0.82, green: 0.70, blue: 0.95, alpha: 1.0)
+                    applyGemMaterial(to: model, color: color3)
+                    
+                    // サイズ・位置調整 (そのまま)
+                    model.scale = SIMD3<Float>(0.005, 0.005, 0.005)
+                    model.position = SIMD3<Float>(0, 0.15, 0)
             
         default:
             // 想定外のモデルが来た時用
             model.scale = SIMD3<Float>(0.1, 0.1, 0.1)
         }
-    } // ★ここで configure 関数を一度閉じます！
+    }
     
-    
-    // 2. ピンクの宝石素材にする関数
-    static func applyPinkGemMaterial(to entity: Entity) {
+    // 2. 汎用的な宝石素材にする関数
+    // ★引数で「color」を受け取れるように変更しました
+    static func applyGemMaterial(to entity: Entity, color: UIColor) {
         
         if let modelEntity = entity as? ModelEntity, modelEntity.model != nil {
             
-            // -----------------------------------------------------------
-            // ★指定された色：#FFD9E6 (サクラピンク)
-            // -----------------------------------------------------------
-            let sakuraPink = UIColor(red: 1.0, green: 0.68, blue: 0.80, alpha: 1.0)
-            
-            // 木の時と同じく、金属(Metaillic)をOFFにすることで
-            // 黒ずみを防ぎ、綺麗な透き通った宝石に見せます
+            // 受け取った色を使って素材を作る
             let material = SimpleMaterial(
-                color: sakuraPink,
-                roughness: 0.0,    // 0にしてツルツルにする
-                isMetallic: false  // ガラス/宝石感を出す
+                color: color,      // 個別の色
+                roughness: 0.0,    // ツルツル
+                isMetallic: false  // 宝石感
             )
             
             // 素材を適用
@@ -82,7 +99,7 @@ struct FlowerModelConfigurator {
         
         // 子供の部品にも同じ処理をする
         for child in entity.children {
-            applyPinkGemMaterial(to: child)
+            applyGemMaterial(to: child, color: color)
         }
     }
 }


### PR DESCRIPTION
# タイトル
feat: 花の成長段階ごとの色分け（カラーバリエーション）実装

# 概要
歩数に応じて成長する「花」の3Dモデルについて、これまでは単色（ピンク）でしたが、成長段階ごとに異なるテーマカラーを設定しました。
これにより、ユーザーが成長の過程を視覚的に楽しめるようになりました。

# 変更点

### 成長段階ごとの色設定 (`FlowerModelConfigurator.swift`)
各モデルの雰囲気に合わせた宝石風のカラーを個別に適用しました。

- **Flower1 (芽):** `ペールシアン` (水色系 / #C0E8F0)
  - 始まりを予感させる、透き通った青色。
- **Flower2 (蕾):** `ペールピンク` (桃色系 / #F8C8DC)
  - 可愛らしさと開花への期待感のあるピンク色。
- **Flower3 (花):** `ライラック` (藤色系 / #D1B2F2)
  - 毒々しさを抑え、上品で達成感のある薄紫色。

### 実装の詳細
- `applyGemMaterial` 関数を改修し、引数で任意の `UIColor` を受け取ってマテリアルを生成できるように変更しました。
- マテリアル設定は共通して `Roughness: 0.0`, `isMetallic: false` (クリスタル質感) を使用しています。

# 補足
-  `ContentView.swift` は変更していません。

# スクリーンショット
<img width="313" height="300" alt="スクリーンショット 2025-12-20 17 28 36" src="https://github.com/user-attachments/assets/7a5ff3c2-3be1-4099-b777-a21a4ec648a1" />
<img width="318" height="313" alt="スクリーンショット 2025-12-20 17 28 51" src="https://github.com/user-attachments/assets/30a3271f-37fa-4a0f-a35d-aeb3b8a42941" />
<img width="320" height="311" alt="スクリーンショット 2025-12-20 17 28 59" src="https://github.com/user-attachments/assets/a73a353e-fc34-45e3-a672-b9a2f93aa2ac" />
