### PR TITLE
樹録するボタンを押したら画面遷移し、獲得したアイテムが樹にコレクションされるロジック実装

### DIFF
--- a/PrismStep/ContentView.swift
+++ b/PrismStep/ContentView.swift
@@ -15,8 +15,11 @@ struct ContentView : View {
     @State var sunAngle: Double = -45.0
     @State var isARMode = false
     
+    // いま選んでいるタブの番号（0:雫, 1:樹）
+    @State private var selectedTab = 0
+    
     var body: some View {
-        TabView {
+        TabView (selection: $selectedTab){//selection: $selectedTab を追加で「selectedTab」の数字が変わると、勝手に画面も切り替わるようになる
             // --- 1枚目の画面（雫） ---
             ZStack {
                 // 背景のカメラ映像
@@ -53,7 +56,7 @@ struct ContentView : View {
                     Spacer()
                 }
                 
-                // ★2. 雫とボタンを表示
+                // 2. 雫とボタンを表示
                 VStack {
                     // 上の余白
                     Spacer().frame(height: 100)
@@ -98,8 +101,7 @@ struct ContentView : View {
                     
                     Spacer()
                 }
-                
-                //new切り替えボタン
+                //newカメラ切り替えボタン
                 VStack{
                     Spacer()
                     Button(action: {
@@ -157,9 +159,16 @@ struct ContentView : View {
                 }
                 
                 if isShowingResult {
-                    ResultDialogView(stepCount: stepManager.todaySteps,closeAction: {
-                        isShowingResult = false
-                    })
+                    ResultDialogView(
+                        stepCount: stepManager.todaySteps,
+                        closeAction: {
+                            isShowingResult = false
+                        },
+                        // 「樹を見に行く」ボタンが押されたら、タブを「1（樹）」に変える命令を渡します
+                        navigateToTreeViewAction: {
+                            selectedTab = 1
+                        }
+                    )
                     .transition(.opacity)
                     .zIndex(1)
                 }
@@ -167,12 +176,14 @@ struct ContentView : View {
             .tabItem {
                 Label("雫", systemImage: "drop")
             }
+            .tag(0) // この画面は「0番」ですよ、という名札
             
             // --- 2枚目の画面（木） ---
             CollectionTreeView()
                 .tabItem {
                     Label("樹", systemImage: "tree")
                 }
+                .tag(1) // この画面は「1番」ですよ、という名札
         }
         .tint(Color(red: 0.87, green: 0.67, blue: 0.3))
     }


### PR DESCRIPTION
## 概要
「樹を見に行く」ボタンを押してダイアログを閉じた後、自動的に「樹（コレクション）」タブへ遷移し、獲得したアイテムが樹の周りに表示されるようにしました。
これにより、「歩く → 育てる → 記録する → コレクションする」というアプリのコア体験が一通り繋がりました。

## 変更点

### 画面遷移・ロジック
- **タブ切り替えの実装**: `ContentView` で `selectedTab` を管理し、ダイアログのボタンアクションでタブを「雫（0）」から「樹（1）」へプログラム的に切り替えられるようにしました。
- **データ渡し（コレクション機能）**: 
    - 獲得したアイテムを保存する配列 `myFlowers` を実装しました。
    - ダイアログで「樹を見に行く」を押すと、その時の歩数データを持った `CollectedFlower` が配列に追加され、CollectionTreeView に渡される仕組みを作りました。

###  樹画面
- **アイテムの表示**: 
    - 3Dの樹（背景）の手前に、獲得したアイテム（花）をリスト表示するようにしました。
    - アイテムは `LazyVGrid` を使用して配置し、3Dモデルのみをシンプルに表示するデザインに調整しました。
    - リスト全体の表示位置を `padding` で調整し、背景の樹と重なっても見栄えが良いようにレイアウトしました。

<img width="282" height="506" alt="スクリーンショット 2025-12-20 23 12 11" src="https://github.com/user-attachments/assets/869f30db-6b99-45cf-9774-06a9768ae2bc" />


## 関連Issue
Closed #46 