### PR TITLE
獲得した花を樹画面に表示する機能の追加

### DIFF
--- a/PrismStep/CollectionTreeView.swift
+++ b/PrismStep/CollectionTreeView.swift
@@ -9,7 +9,17 @@ import SwiftUI
 import RealityKit
 
 struct CollectionTreeView: View {
+    
+    // 親から受け取るリスト
+    var flowers: [CollectedFlower]
+    
+    // グリッドのレイアウト設定（小さめのアイコンを並べる）
+    let columns = [
+        GridItem(.adaptive(minimum: 150)) // 幅80くらいのアイテムを詰め込む
+    ]
+    
     var body: some View {
+        
         ZStack {
             // 背景色（とりあえず緑）
             Color.green.opacity(0.2)
@@ -39,10 +49,50 @@ struct CollectionTreeView: View {
                     print("エラー：木のモデルが見つかりません。ファイル名を確認してください！")
                 }
             }
+            
+            // ▼▼▼ 2. 手前：獲得したアイテムリスト（左上に表示） ▼▼▼
+            //VStack(alignment: .leading) { // 左寄せ
+            
+            if !flowers.isEmpty {
+                
+                // スクロールできるエリア
+                ScrollView {
+                    LazyVGrid(columns: columns, spacing: 15) {
+                        
+                        // リストの中身を一個ずつ取り出して表示
+                        ForEach(flowers) { flower in
+                            // 小さい3Dの花を表示
+                            Flower3DView(stepCount: flower.stepCount, scale: 1.8, isRotating: true)
+                                .frame(width: 100, height: 100)
+                            // yをプラスにすると下へ、マイナスにすると上へ動きます
+                                .offset(x:-20,y: -120)
+                            //.background(Material.ultraThin) // すりガラス風の丸背景（個別に適用）
+                            //.clipShape(Circle())
+                            //.shadow(radius: 5)
+                            
+                        }
+                    }
+                    .padding()
+                    // ★ここを追加！数字を大きくするほど下に下がります
+                    .padding(.top, 300)
+                }
+                // .frame(maxHeight: 200) // リストの高さ（画面全体を埋めないように制限）
+                
+                // .padding()
+            }
+            
+            Spacer() // 残りのスペースを空けて、リストを上に押しやる
         }
+        // 画面の幅いっぱいに広げて、左上（topLeading）に寄せる
+        .frame(maxWidth: .infinity, alignment: .topLeading)
     }
 }
 
+
 #Preview {
-    CollectionTreeView()
+    CollectionTreeView(flowers: [
+        CollectedFlower(stepCount: 3000), // 芽
+        CollectedFlower(stepCount: 8500), // 花
+        CollectedFlower(stepCount: 5000)  // 蕾
+    ])
 }

--- a/PrismStep/ContentView.swift
+++ b/PrismStep/ContentView.swift
@@ -18,6 +18,9 @@ struct ContentView : View {
     // いま選んでいるタブの番号（0:雫, 1:樹）
     @State private var selectedTab = 0
     
+    // 獲得した花を入れる（リスト）
+        @State private var myFlowers: [CollectedFlower] = []
+    
     var body: some View {
         TabView (selection: $selectedTab){//selection: $selectedTab を追加で「selectedTab」の数字が変わると、勝手に画面も切り替わるようになる
             // --- 1枚目の画面（雫） ---
@@ -166,6 +169,8 @@ struct ContentView : View {
                         },
                         // 「樹を見に行く」ボタンが押されたら、タブを「1（樹）」に変える命令を渡します
                         navigateToTreeViewAction: {
+                            let newFlower = CollectedFlower(stepCount: stepManager.todaySteps)
+                                                        myFlowers.append(newFlower)
                             selectedTab = 1
                         }
                     )
@@ -179,7 +184,7 @@ struct ContentView : View {
             .tag(0) // この画面は「0番」ですよ、という名札
             
             // --- 2枚目の画面（木） ---
-            CollectionTreeView()
+            CollectionTreeView(flowers: myFlowers)
                 .tabItem {
                     Label("樹", systemImage: "tree")
                 }
@@ -187,6 +192,12 @@ struct ContentView : View {
         }
         .tint(Color(red: 0.87, green: 0.67, blue: 0.3))
     }
+}
+
+// 獲得した花のデータ
+struct CollectedFlower: Identifiable {
+    let id = UUID()      // ID（これがないとSwiftUIが区別できない）
+    let stepCount: Int   // 何歩で手に入れたか（これで花の種類を決める）
 }
 
 #Preview {


### PR DESCRIPTION
## 概要
前回の作業でコミット漏れにより反映されていなかった、「樹録後の画面遷移」および「獲得アイテムのコレクション表示機能」を復旧し、正しく実装しました。

## 変更点

### 機能の復旧（リカバリ）
- **画面遷移ロジック**: ダイアログの「樹を見に行く」ボタンをタップした際、正しく「樹（コレクション）」タブへ遷移する処理を適用しました。
- **データ連携**: 獲得したアイテム（`CollectedFlower`）を配列に追加し、コレクション画面へ受け渡すロジックを反映させました。

###  樹（コレクション）画面の実装
- **リスト表示**: 獲得したアイテムが、3Dの樹（背景）の手前にリスト表示されるレイアウトを適用しました。
    - `LazyVGrid` を使用してアイテムを整列。
    - アイテム単体（3Dモデル）のデザイン調整（背景削除など）。
    - リスト全体の位置を `padding` で調整し、背景の樹と重ならないように配置。


## 補足
- 前回のプルリク後に手元に残っていた変更（Stash）を適用し、改めてコミットし直したものです。